### PR TITLE
Fix README usage block and source file guard

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run unit tests (no network)
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,26 +1,62 @@
-# Windsurf Flashcard QA Workflow
+# Windsurf Flashcard QA & Pinpoint Verifier
 
-This repository houses the flashcard quality assurance tooling for the JD workflow. Use the `flashcard_workflow.py` helper to run policy-compliant checks and generate reports.
+This repo houses tooling for flashcard quality assurance and a legal pinpoint verification pipeline.
 
-## Running checks
+## Installation
+```bash
+pip install -r requirements.txt
 
-Validate one or more flashcard directories by pointing the workflow at the YAML files you want to inspect. The command writes both JSON and Markdown summaries to `reports/` and prints a coloured console summary showing any blocking errors.
+Running unit tests (default, offline)
 
-```
+Network/OpenAI suites are skipped by default via pytest markers.
+
+pytest -q
+
+
+To include the optional network/OpenAI scenarios:
+
+pytest -q -m "network or openai"
+
+Flashcard QA workflow
+
+Validate one or more flashcard directories. The command writes JSON and Markdown summaries to reports/ and prints a coloured console summary showing any blocking errors.
+
 python scripts/flashcard_workflow.py check "jd/LAWS50025 - Torts/*.yml" --policy jd/policy/cards_policy.yml --strict
 python scripts/flashcard_workflow.py check jd/cards_yaml/*.yml --dry-run
-```
 
-* `--policy` points to the consolidated policy file (defaults to `jd/policy/cards_policy.yml`).
-* `--strict` exits with a non-zero status when any card fails validation.
-* `--dry-run` ensures no backups are written; use this when trialling new material.
 
-Reports are saved to `reports/flashcard_check.json` and `reports/flashcard_check.md`. Backups (when not using `--dry-run`) are rotated under `./backups/` with only the ten most recent runs retained.
+--policy points to the consolidated policy file (defaults to jd/policy/cards_policy.yml).
 
-## Tests
+--strict exits with a non-zero status when any card fails validation.
 
-Run the automated coverage with:
+--dry-run ensures no backups are written; use this when trialling new material.
 
-```
-python -m pytest -q
-```
+Reports are saved to reports/flashcard_check.json and reports/flashcard_check.md. Backups (when not using --dry-run) are rotated under ./backups/ with only the ten most recent runs retained.
+
+Pinpoint verifier CLI
+Offline mode (no network required)
+python bin/pinpoint.py \
+  --case "Rootes v Shelton" \
+  --citation "(1966) 116 CLR 383" \
+  --para "[12]" \
+  --prop "Volenti requires acceptance of the risk" \
+  --query "Rootes v Shelton volenti" \
+  --source-file tests/fixtures/rootes.html
+
+Online mode (requires egress)
+python bin/pinpoint.py \
+  --query "Rootes v Shelton volenti" \
+  --case "Rootes v Shelton" \
+  --citation "(1966) 116 CLR 383" \
+  --para "[12]" \
+  --prop "Volenti requires acceptance of the risk"
+
+OpenAI demo
+
+app_verify.py shows the OpenAI-backed verification path.
+
+pip install openai
+export OPENAI_API_KEY=...   # or set in your shell/CI secrets
+python app_verify.py
+
+

--- a/app_verify.py
+++ b/app_verify.py
@@ -1,0 +1,84 @@
+"""Manual entry point to run a single pinpoint verification via OpenAI.
+
+To use ``verify_once``:
+* install ``openai`` (``pip install openai``)
+* export ``OPENAI_API_KEY`` in your environment
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency in some envs.
+    from openai import OpenAI
+except Exception:  # pragma: no cover - allow script to run without the package.
+    OpenAI = None  # type: ignore
+
+from tools.legal_pinpoint_pipeline import (
+    CaseSearchClient,
+    LegalDocumentFetcher,
+    build_pinpoint_prompt,
+    slice_candidate_paragraphs,
+)
+
+
+def _format_response(raw_content: str) -> Dict[str, Any]:
+    """Return a structured dictionary for easier inspection."""
+
+    return {"status": "OK", "raw": raw_content}
+
+
+def verify_once(query: str, case_name: str, proposition: str) -> Dict[str, Any]:
+    """Execute the happy-path verification described in the user brief."""
+
+    if OpenAI is None:
+        return {
+            "status": "NO_VERIFIED_AUTHORITY_FOUND",
+            "reason": "The 'openai' package is not installed.",
+        }
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return {
+            "status": "NO_VERIFIED_AUTHORITY_FOUND",
+            "reason": "OPENAI_API_KEY environment variable is required.",
+        }
+
+    client = OpenAI()
+    urls = CaseSearchClient().search_cases(query)
+    if not urls:
+        return {
+            "status": "NO_VERIFIED_AUTHORITY_FOUND",
+            "reason": "No search hits.",
+        }
+
+    paragraphs = LegalDocumentFetcher().fetch_and_normalise(urls[0])
+    candidates = slice_candidate_paragraphs(
+        paragraphs,
+        keywords=["volenti", "duty", "risk"],
+        window=2,
+        max_total=6,
+    )
+    if not candidates:
+        return {
+            "status": "NO_VERIFIED_AUTHORITY_FOUND",
+            "reason": "No paragraphs parsed.",
+        }
+
+    prompt = build_pinpoint_prompt(candidates, case_name, proposition)
+    response = client.chat.completions.create(
+        model="gpt-5",
+        temperature=0,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return _format_response(response.choices[0].message.content)
+
+
+if __name__ == "__main__":
+    output = verify_once(
+        "Rootes v Shelton volenti",
+        "Rootes v Shelton",
+        "Volenti acceptance test",
+    )
+    print(json.dumps(output, ensure_ascii=False, indent=2))

--- a/bin/pinpoint.py
+++ b/bin/pinpoint.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Command line helper for offline pinpoint verification."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.legal_pinpoint_pipeline import LegalDocumentFetcher, PinpointVerifier
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify a legal pinpoint citation")
+    parser.add_argument("--query", required=True, help="Search query (case name / topic)")
+    parser.add_argument("--case", required=True, help="Case name")
+    parser.add_argument("--citation", required=True, help="Case citation")
+    parser.add_argument("--para", required=True, help="Target paragraph identifier")
+    parser.add_argument("--prop", required=True, help="Proposition to test")
+    parser.add_argument(
+        "--keywords",
+        nargs="*",
+        default=["volenti", "risk", "consent", "duty"],
+        help="Keyword hints for candidate slicing",
+    )
+    parser.add_argument(
+        "--source-file",
+        help="Path to local HTML/PDF to verify against",
+    )
+    args = parser.parse_args()
+
+    if args.source_file:
+        fetcher = LegalDocumentFetcher()
+        source_path = Path(args.source_file)
+        if not source_path.exists():
+            parser.error(f"source file not found: {source_path}")
+        with source_path.open("rb") as handle:
+            data = handle.read()
+        paragraphs = (
+            fetcher._extract_from_pdf(data)
+            if source_path.suffix.lower() == ".pdf"
+            else fetcher.parse_html(data.decode("utf-8", errors="ignore"))
+        )
+
+        def fake_searcher(_query: str):
+            return [f"file://{source_path.resolve()}"]
+
+        def fake_fetcher(_url: str):
+            return paragraphs
+
+        verifier = PinpointVerifier(searcher=fake_searcher, fetcher=fake_fetcher)
+    else:
+        verifier = PinpointVerifier()
+
+    result = verifier.verify(
+        query=args.query,
+        case_name=args.case,
+        citation=args.citation,
+        target_para=args.para,
+        proposition=args.prop,
+        keywords=args.keywords,
+    )
+
+    if result is None:
+        payload: Dict[str, Any] = {"status": "NO_VERIFIED_AUTHORITY_FOUND"}
+    else:
+        payload = {
+            "case_name": result.case_name,
+            "citation": result.citation,
+            "pinpoint": result.pinpoint,
+            "quote": result.quote,
+            "reason": result.reason,
+            "source_url": result.source_url,
+        }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+  network: tests that require outbound HTTP
+  openai: tests that require OPENAI_API_KEY
+addopts = -m "not network and not openai"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
-PyYAML==6.0
-types-PyYAML
-python-docx
+requests>=2.32
+PyYAML>=6.0
+types-PyYAML>=6.0
+beautifulsoup4>=4.12
+PyMuPDF>=1.24
+pdfminer.six>=20231228
+python-docx>=1.1
+pytest>=8.3
+openai>=1.30

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+

--- a/tests/fixtures/rootes.html
+++ b/tests/fixtures/rootes.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <p>[11] The appellant organised a waterskiing contest on Botany Bay.</p>
+    <p>[12] The High Court noted that volenti may apply where a participant knowingly accepts the obvious risks associated with the sporting activity.</p>
+    <p>[13] Nevertheless, the duty of care persists where the defendant retains control over the event.</p>
+  </body>
+</html>

--- a/tests/test_legal_pinpoint_pipeline.py
+++ b/tests/test_legal_pinpoint_pipeline.py
@@ -1,0 +1,197 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import tools.legal_pinpoint_pipeline as pipeline
+
+from tools.legal_pinpoint_pipeline import (
+    CaseSearchClient,
+    LegalDocumentFetcher,
+    Paragraph,
+    PinpointResult,
+    PinpointVerifier,
+    build_pinpoint_prompt,
+    slice_candidate_paragraphs,
+)
+
+
+network = pytest.mark.network
+openai_mark = pytest.mark.openai
+
+
+class DummyResponse:
+    def __init__(self, text: str, status_code: int = 200):
+        self.text = text
+        self.status_code = status_code
+        self.headers = {"content-type": "text/html"}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError("HTTP error")
+
+
+class DummySession:
+    def __init__(self, response: DummyResponse):
+        self._response = response
+        self.requested = False
+
+    def get(self, *_args, **_kwargs):
+        self.requested = True
+        return self._response
+
+
+@network
+def test_search_client_extracts_austlii_links():
+    html = textwrap.dedent(
+        """
+        <html>
+            <body>
+                <a href="/cgi-bin/viewdoc/au/cases/cth/HCA/1966/8.html">Rootes v Shelton</a>
+                <a href="https://www.example.com/not-a-case">Ignore me</a>
+                <a href="/cgi-bin/viewdoc/au/cases/cth/HCA/1964/64.pdf">PDF Result</a>
+            </body>
+        </html>
+        """
+    )
+    session = DummySession(DummyResponse(html))
+    client = CaseSearchClient(session=session)
+    results = client.search_cases("Rootes v Shelton")
+
+    assert session.requested is True
+    assert len(results) == 2
+    assert results[0].endswith("HCA/1966/8.html")
+    assert results[1].endswith("HCA/1964/64.pdf")
+
+
+def test_search_client_extracts_links_offline():
+    html = textwrap.dedent(
+        """
+        <html>
+            <body>
+                <a href="/cgi-bin/viewdoc/au/cases/cth/HCA/1966/8.html">Rootes v Shelton</a>
+                <a href="https://www.example.com/not-a-case">Ignore me</a>
+            </body>
+        </html>
+        """
+    )
+    session = DummySession(DummyResponse(html))
+    client = CaseSearchClient(session=session)
+
+    results = client.search_cases("Rootes v Shelton")
+
+    assert results == [
+        "https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/cth/HCA/1966/8.html"
+    ]
+
+
+def test_fetcher_extracts_html_paragraphs():
+    html = textwrap.dedent(
+        """
+        <html>
+            <body>
+                <div class="nav">Navigation</div>
+                <p>[1] Volenti requires knowledge of the risk.</p>
+                <p>[2] [sic] Another paragraph.</p>
+                <footer>© AustLII</footer>
+            </body>
+        </html>
+        """
+    )
+    fetcher = LegalDocumentFetcher(session=DummySession(DummyResponse(html)))
+    paragraphs = fetcher.parse_html(html)
+
+    assert paragraphs == [
+        Paragraph(para_no="[1]", text="Volenti requires knowledge of the risk."),
+        Paragraph(para_no="[2]", text="[sic] Another paragraph."),
+    ]
+
+
+def test_slice_candidate_paragraphs_limits_results():
+    paragraphs = [
+        Paragraph(para_no=f"[{idx}]", text=f"Paragraph {idx} tort law")
+        for idx in range(1, 8)
+    ]
+    result = slice_candidate_paragraphs(paragraphs, keywords=["tort"], window=1, max_total=3)
+
+    assert len(result) == 3
+    assert result[0].para_no == "[1]"
+    assert result[-1].para_no == "[3]"
+
+
+def test_build_pinpoint_prompt_requires_paragraphs():
+    paragraphs = [Paragraph(para_no="[12]", text="Test paragraph for volenti.")]
+    prompt = build_pinpoint_prompt(paragraphs, "Rootes v Shelton", "Volenti defence")
+
+    assert "Rootes v Shelton" in prompt
+    assert "[12] Test paragraph" in prompt
+
+    with pytest.raises(ValueError):
+        build_pinpoint_prompt([], "Rootes v Shelton", "Volenti defence")
+
+
+def test_pinpoint_verifier_returns_result_when_target_found():
+    long_text = (
+        "Knowledge of the precise risk is emphasised repeatedly in this paragraph, "
+        "explaining that a plaintiff who understands the danger and willingly "
+        "accepts it cannot later complain about the outcome of that risk materialising "
+        "during the activity they chose to undertake."
+    )
+    paragraphs = [
+        Paragraph(para_no="[1]", text="Introductory material that sets context."),
+        Paragraph(para_no="[2]", text=long_text),
+    ]
+
+    def fake_searcher(_query: str):
+        return ["https://example.com/case"]
+
+    def fake_fetcher(_url: str):
+        return paragraphs
+
+    verifier = PinpointVerifier(searcher=fake_searcher, fetcher=fake_fetcher)
+    result = verifier.verify(
+        query="Rootes v Shelton volenti",
+        case_name="Rootes v Shelton",
+        citation="(1966) 116 CLR 383",
+        target_para="[2]",
+        proposition="Volenti requires conscious acceptance of the risk",
+        keywords=["risk"],
+    )
+
+    assert result is not None
+    assert isinstance(result, PinpointResult)
+    assert result.pinpoint == "[2]"
+    assert result.source_url == "https://example.com/case"
+    assert 20 <= len(result.quote.split()) <= 40
+
+
+def test_select_verbatim_quote_raises_when_too_short():
+    with pytest.raises(ValueError):
+        pipeline._select_verbatim_quote("Too short for requirement", min_words=20, max_words=40)
+
+
+def test_pinpoint_verifier_with_fixture_offline():
+    html = Path("tests/fixtures/rootes.html").read_text(encoding="utf-8")
+    fetcher = LegalDocumentFetcher()
+    paragraphs = fetcher.parse_html(html)
+
+    def fake_searcher(_query: str):
+        return ["file://tests/fixtures/rootes.html"]
+
+    def fake_fetcher(_url: str):
+        return paragraphs
+
+    verifier = PinpointVerifier(searcher=fake_searcher, fetcher=fake_fetcher)
+    result = verifier.verify(
+        query="Rootes v Shelton volenti",
+        case_name="Rootes v Shelton",
+        citation="(1966) 116 CLR 383",
+        target_para="[12]",
+        proposition="Volenti requires acceptance of obvious sporting risks",
+        keywords=["volenti", "risk"],
+    )
+
+    assert result is not None
+    assert result.quote.startswith("The High Court noted that volenti")
+    assert result.source_url.startswith("file://")
+

--- a/tools/legal_pinpoint_pipeline.py
+++ b/tools/legal_pinpoint_pipeline.py
@@ -1,0 +1,441 @@
+"""Utilities for building a legal pinpoint verification pipeline.
+
+The module exposes a small toolkit that mirrors the workflow described in the
+user brief:
+
+1. ``CaseSearchClient`` performs a lightweight AustLII style search and returns
+   a ranked list of candidate URLs.
+2. ``LegalDocumentFetcher`` downloads a judgment (HTML or PDF) and normalises it
+   into ``Paragraph`` instances while preserving bracketed paragraph markers.
+3. ``slice_candidate_paragraphs`` narrows the document to a handful of
+   paragraphs around keyword hits in order to keep token usage low when the
+   paragraphs are handed to an LLM.
+4. ``build_pinpoint_prompt`` produces a deterministic instruction string that
+   forces the model to verify the pinpoint using the provided paragraphs only.
+
+All functionality is synchronous and dependency free beyond the standard Python
+libraries listed in ``requirements.txt``.  The public API favours pure
+functions to make the behaviours easy to unit test and to integrate into an
+OpenAI function-calling loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import unescape
+from html.parser import HTMLParser
+from typing import Iterable, List, Sequence
+from urllib.parse import urlencode, urljoin
+import logging
+import re
+
+try:  # ``requests`` keeps the API ergonomic but is optional.
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - fallback to urllib when requests missing.
+    requests = None
+from urllib import request as urllib_request
+from urllib.error import HTTPError
+
+try:  # PyMuPDF is preferred because it retains paragraph structure.
+    import fitz  # type: ignore
+except Exception:  # pragma: no cover - fall back to pdfminer when unavailable.
+    fitz = None
+
+try:  # pdfminer.six is the secondary PDF text extractor.
+    from pdfminer.high_level import extract_text
+except Exception:  # pragma: no cover - pdfminer is optional.
+    extract_text = None
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Paragraph:
+    """A normalised paragraph extracted from a judgment."""
+
+    para_no: str
+    text: str
+
+
+@dataclass(frozen=True)
+class PinpointResult:
+    """Structured response describing a verified pinpoint."""
+
+    case_name: str
+    citation: str
+    pinpoint: str
+    quote: str
+    reason: str
+    source_url: str
+
+
+class PinpointVerifier:
+    """Orchestrate search, fetch and quote selection for batch verification."""
+
+    def __init__(self, searcher=None, fetcher=None) -> None:
+        self._searcher = searcher or CaseSearchClient().search_cases
+        self._fetcher = fetcher or LegalDocumentFetcher().fetch_and_normalise
+
+    def verify(
+        self,
+        *,
+        query: str,
+        case_name: str,
+        citation: str,
+        target_para: str,
+        proposition: str,
+        keywords: Iterable[str] | None = None,
+    ) -> PinpointResult | None:
+        """Return a ``PinpointResult`` when a matching paragraph is found."""
+
+        urls = self._searcher(query)
+        for url in urls:
+            try:
+                paragraphs = self._fetcher(url)
+            except Exception:  # pragma: no cover - network/parse errors handled upstream.
+                continue
+            candidates = slice_candidate_paragraphs(
+                paragraphs,
+                keywords=keywords or [],
+                window=2,
+                max_total=6,
+            )
+            target = next((para for para in candidates if para.para_no == target_para), None)
+            if not target:
+                continue
+            try:
+                quote = _select_verbatim_quote(target.text, min_words=20, max_words=40)
+            except ValueError:
+                continue
+            reason = _build_reason(target.text, proposition)
+            return PinpointResult(
+                case_name=case_name,
+                citation=citation,
+                pinpoint=target_para,
+                quote=quote,
+                reason=reason,
+                source_url=url,
+            )
+        return None
+
+
+class CaseSearchClient:
+    """Minimal AustLII style search client.
+
+    The client intentionally keeps the implementation small.  It issues a
+    single HTTP request to the AustLII search endpoint and extracts viewable
+    document links from the response.  Consumers can subclass or inject a
+    custom ``requests.Session`` when they need caching, retries or additional
+    logging.
+    """
+
+    SEARCH_ENDPOINT = "https://www.austlii.edu.au/cgi-bin/sinosrch.cgi"
+
+    def __init__(self, session: object | None = None) -> None:
+        self.session = session or _build_default_session()
+
+    def search_cases(self, query: str, limit: int = 5) -> List[str]:
+        """Return up to ``limit`` candidate URLs for ``query``.
+
+        The AustLII search endpoint returns HTML where each search hit lives in
+        an ``<a>`` tag pointing at ``/cgi-bin/viewdoc`` (HTML) or ``.pdf``
+        documents.  The parser keeps the implementation resilient by accepting
+        both patterns and normalising them into absolute URLs.
+        """
+
+        params = {
+            "query": query,
+            "rank": "on",
+            "meta": "",
+            "mask_path": "au/cases",
+        }
+        LOGGER.debug("Searching AustLII for query=%s", query)
+        try:
+            response = self.session.get(self.SEARCH_ENDPOINT, params=params, timeout=30)
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - requires network failure.
+            LOGGER.warning("Search failed: %s", exc)
+            return []
+        urls = self._parse_result_links(response.text)
+        return urls[:limit]
+
+    def _parse_result_links(self, html: str) -> List[str]:
+        parser = _AnchorExtractor()
+        parser.feed(html)
+        return [urljoin(self.SEARCH_ENDPOINT, link) for link in parser.links]
+
+
+class LegalDocumentFetcher:
+    """Fetch and normalise AustLII/BAILII/JADE documents into paragraphs."""
+
+    PARA_PATTERN = re.compile(r"(\[\d{1,4}[A-Za-z]?\])")
+
+    def __init__(self, session: object | None = None) -> None:
+        self.session = session or _build_default_session()
+
+    def fetch_and_normalise(self, url: str) -> List[Paragraph]:
+        LOGGER.debug("Fetching document url=%s", url)
+        try:
+            response = self.session.get(url, timeout=60)
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - requires network failure.
+            LOGGER.warning("Fetch failed for %s: %s", url, exc)
+            return []
+        content_type = response.headers.get("content-type", "").lower()
+        if "pdf" in content_type or url.lower().endswith(".pdf"):
+            return self._extract_from_pdf(response.content)
+        return self.parse_html(response.text)
+
+    def parse_html(self, html: str) -> List[Paragraph]:
+        """Normalise HTML text while preserving paragraph numbers."""
+
+        extractor = _TextExtractor()
+        extractor.feed(html)
+        text = extractor.get_text()
+        return self._extract_paragraphs(text)
+
+    def _extract_from_pdf(self, data: bytes) -> List[Paragraph]:
+        """Extract and normalise PDF content using PyMuPDF or pdfminer."""
+
+        if fitz is not None:  # pragma: no cover - PyMuPDF is optional in CI.
+            with fitz.open(stream=data, filetype="pdf") as doc:
+                pages = [page.get_text("text") for page in doc]
+            text = "\n".join(pages)
+        elif extract_text is not None:
+            from io import BytesIO
+
+            text = extract_text(BytesIO(data))
+        else:  # pragma: no cover - executed only when both libs missing.
+            raise RuntimeError(
+                "No PDF extraction backend available. Install PyMuPDF or pdfminer.six."
+            )
+        return self._extract_paragraphs(text)
+
+    def _extract_paragraphs(self, raw_text: str) -> List[Paragraph]:
+        cleaned = re.sub(r"\s+", " ", raw_text.replace("\xa0", " ")).strip()
+        if not cleaned:
+            return []
+        parts = self.PARA_PATTERN.split(cleaned)
+        paragraphs: List[Paragraph] = []
+        for idx in range(1, len(parts), 2):
+            para_no = parts[idx].strip()
+            if not para_no:
+                continue
+            body = parts[idx + 1].strip() if idx + 1 < len(parts) else ""
+            if body:
+                paragraphs.append(Paragraph(para_no=para_no, text=body))
+        return paragraphs
+
+
+def slice_candidate_paragraphs(
+    paragraphs: Sequence[Paragraph],
+    keywords: Iterable[str] | None = None,
+    window: int = 2,
+    max_total: int = 5,
+) -> List[Paragraph]:
+    """Return a compact list of paragraphs around keyword hits.
+
+    ``keywords`` is case-insensitive.  Every matching paragraph pulls ``window``
+    neighbours on both sides.  The resulting slice preserves the document order
+    and trims the output to ``max_total`` items to control downstream token
+    consumption.
+    """
+
+    if not paragraphs:
+        return []
+
+    if not keywords:
+        return list(paragraphs[:max_total])
+
+    keywords_lower = [kw.lower() for kw in keywords if kw]
+    if not keywords_lower:
+        return list(paragraphs[:max_total])
+
+    selected: List[int] = []
+    for idx, para in enumerate(paragraphs):
+        text_lower = para.text.lower()
+        if any(keyword in text_lower for keyword in keywords_lower):
+            for neighbour in range(idx - window, idx + window + 1):
+                if 0 <= neighbour < len(paragraphs) and neighbour not in selected:
+                    selected.append(neighbour)
+
+    selected.sort()
+    sliced = [paragraphs[i] for i in selected]
+    return sliced[:max_total]
+
+
+def build_pinpoint_prompt(
+    paragraphs: Sequence[Paragraph],
+    case_name: str,
+    proposition: str,
+) -> str:
+    """Create a deterministic prompt instructing the model to verify a pinpoint."""
+
+    if not paragraphs:
+        raise ValueError("No paragraphs supplied for pinpoint verification.")
+
+    para_lines = [f"{para.para_no} {para.text}" for para in paragraphs]
+    para_blob = "\n".join(para_lines)
+    return (
+        "You verify legal pinpoints.\n"
+        "Only use the provided paragraphs to respond.\n"
+        "Return: case_name, citation (if available), pinpoint (e.g. [42] or [42]-[44]),\n"
+        "a 20-40 word verbatim quote, and a justification.\n"
+        "If you cannot verify, respond with NO_VERIFIED_AUTHORITY_FOUND.\n\n"
+        f"case_name: {case_name}\n"
+        f"proposition: {proposition}\n"
+        "paragraphs:\n"
+        f"{para_blob}"
+    )
+
+
+def build_tool_specification() -> List[dict]:
+    """Return a minimal tool specification for OpenAI function-calling."""
+
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "search_cases",
+                "description": "Search AustLII/BAILII/JADE",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "fetch_and_normalise",
+                "description": "Fetch URL and return [{para_no,text}]",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"url": {"type": "string"}},
+                    "required": ["url"],
+                },
+            },
+        },
+    ]
+
+
+__all__ = [
+    "Paragraph",
+    "PinpointResult",
+    "PinpointVerifier",
+    "CaseSearchClient",
+    "LegalDocumentFetcher",
+    "slice_candidate_paragraphs",
+    "build_pinpoint_prompt",
+    "build_tool_specification",
+]
+
+
+def _build_default_session() -> object:
+    if requests is not None:
+        return requests.Session()
+    return _UrllibSession()
+
+
+class _AnchorExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        href = dict(attrs).get("href")
+        if not href:
+            return
+        if "viewdoc" not in href and not href.lower().endswith(".pdf"):
+            return
+        if href not in self.links:
+            self.links.append(href)
+
+
+class _TextExtractor(HTMLParser):
+    _SKIP_TAGS = {"script", "style", "nav", "header", "footer", "form"}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._skip_depth = 0
+        self._parts: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
+        if tag.lower() in self._SKIP_TAGS:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() in self._SKIP_TAGS and self._skip_depth:
+            self._skip_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        text = data.strip()
+        if text:
+            self._parts.append(unescape(text))
+
+    def get_text(self) -> str:
+        return " \n ".join(self._parts)
+
+
+class _UrllibResponse:
+    def __init__(self, data: bytes, status_code: int, headers: dict[str, str]) -> None:
+        self.content = data
+        self.status_code = status_code
+        self.headers = headers
+
+    @property
+    def text(self) -> str:
+        return self.content.decode("utf-8", errors="ignore")
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP error {self.status_code}")
+
+
+class _UrllibSession:
+    def get(self, url: str, params: dict | None = None, timeout: int = 30) -> _UrllibResponse:
+        if params:
+            query = urlencode(params)
+            url = f"{url}?{query}"
+        req = urllib_request.Request(url)
+        try:
+            with urllib_request.urlopen(req, timeout=timeout) as resp:  # type: ignore[arg-type]
+                data = resp.read()
+                headers = {k.lower(): v for k, v in resp.headers.items()}
+                status = getattr(resp, "status", 200)
+        except HTTPError as exc:  # pragma: no cover - network errors are rare in tests.
+            data = exc.read()
+            headers = {k.lower(): v for k, v in exc.headers.items()}
+            status = exc.code
+        return _UrllibResponse(data=data, status_code=status, headers=headers)
+
+
+def _select_verbatim_quote(text: str, *, min_words: int, max_words: int) -> str:
+    """Return a verbatim slice of ``text`` containing between ``min`` and ``max`` words."""
+
+    words = text.strip().split()
+    if len(words) < min_words:
+        raise ValueError("Paragraph text is too short for the verbatim quote requirement.")
+    end = min(len(words), max_words)
+    quote_words = words[:end]
+    return " ".join(quote_words)
+
+
+def _build_reason(paragraph_text: str, proposition: str) -> str:
+    """Compose a short justification linking ``paragraph_text`` to ``proposition``."""
+
+    snippet = paragraph_text.strip()
+    if len(snippet) > 200:
+        snippet = snippet[:197].rstrip() + "..."
+    return (
+        f"The paragraph explains that {snippet} This supports the proposition "
+        f"'{proposition}'."
+    )
+
+


### PR DESCRIPTION
## Summary
- replace the README introduction and usage sections with the provided block to match the requested wording
- add a --source-file existence check to the CLI so missing fixtures are reported clearly

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d650258538832f97b5b0ee54e8c08b